### PR TITLE
Fix UnicodeDecodeError when tempdir contains special characters

### DIFF
--- a/opensesame_extensions/OpenScienceFramework/OpenScienceFramework.py
+++ b/opensesame_extensions/OpenScienceFramework/OpenScienceFramework.py
@@ -835,7 +835,10 @@ class OpenScienceFramework(base_extension):
 
         # Store the token in the temp dir (it is only valid for an hour, so this
         # doesn't seem to be a real security risk)
-        tmp_dir = safe_decode(tempfile.gettempdir())
+        tmp_dir = safe_decode(
+            tempfile.gettempdir(),
+            enc=sys.getfilesystemencoding()
+        )
         self.tokenfile = os.path.join(tmp_dir, 'OS_OSF.json')
 
         # Create manager object


### PR DESCRIPTION
Important to know: functions that work with file paths do generally use the filesystem encoding, which (annoyingly) can be different from the default system encoding. So you have explicitly indicate this when using `safe_decode()`.

Could you merge this, check it, and release it as 1.2.1?